### PR TITLE
Prevent multi-threading race conditions and add a dunce feature

### DIFF
--- a/TFCELO.py
+++ b/TFCELO.py
@@ -185,8 +185,9 @@ async def dunce(ctx, player: discord.Member, reason=None):
                 ELOpop[str(player.id)][PLAYER_MAP_DUNCE_FLAG_INDEX] = reason
                 await ctx.send(f"{player.display_name} is a dunce! Reason: {reason}")
         else:
+            originalReason = ELOpop[str(player.id)][PLAYER_MAP_DUNCE_FLAG_INDEX]
             ELOpop[str(player.id)][PLAYER_MAP_DUNCE_FLAG_INDEX] = None
-            await ctx.send(f"{player.display_name} is no longer a dunce! (original reason: {reason})")
+            await ctx.send(f"{player.display_name} is no longer a dunce! (original reason: {originalReason})")
 
         # Write ELO database changes out
         with open('ELOpop.json', 'w') as cd:

--- a/variables.json
+++ b/variables.json
@@ -11,7 +11,7 @@
     "rank9": "<:rank9:1000673940173242378>",
     "rank10": "<:rank10:1000673949761417306>",
     "rankS": "<:rankS:1003216122205708359>",
-    "TOKEN": "NTY0MjU2NzQxNTIxMzU4ODU4.GNn1Ov.8zjNhtwXDVj9Grf2uyaacJdhQTsTf4vxOCxYvc",
+    "TOKEN": "TOKEN",
     "t1img": "<:blueLogo:971553179508551731>",
     "t2img": "<:redLogo:971553150467178566>",
     "cptimg": "<:cptimg:972371136191025152>",

--- a/variables.json
+++ b/variables.json
@@ -1,4 +1,5 @@
 {
+	"dunce": "<:dunce2:1086199426500005908>",
     "rank1": "<:rank1:1000673846879326208>", 
     "rank2": "<:rank2:1000673858501738497>",
     "rank3": "<:rank3:1000673873018232934>",
@@ -10,7 +11,7 @@
     "rank9": "<:rank9:1000673940173242378>",
     "rank10": "<:rank10:1000673949761417306>",
     "rankS": "<:rankS:1003216122205708359>",
-    "TOKEN": "NTY0MjU2NzQxNTIxMzU4ODU4.GYBmE2.5kCc33t6vXEA5jHJq8rJ2GQ_IbL8tvfDLMf4Bo",
+    "TOKEN": "NTY0MjU2NzQxNTIxMzU4ODU4.GNn1Ov.8zjNhtwXDVj9Grf2uyaacJdhQTsTf4vxOCxYvc",
     "t1img": "<:blueLogo:971553179508551731>",
     "t2img": "<:redLogo:971553150467178566>",
     "cptimg": "<:cptimg:972371136191025152>",


### PR DESCRIPTION
Prevent multi-threading race conditions with a global lock.  The convention is to add a lock around any user command or event handler (anything with a discord tag).  Utility functions should not a lock to prevent deadlock.  Consider using re-entrant locks in the future if this gets to complicated.

Add a 'dunce' feature to keep track of trouble makers and lightly shame them without all the bad feelings that come with not being able to actually play.  Currently replaces achievement list with a single dunce cap image and shows the dunce reason.  Also forces rating to be shown.