### PR TITLE
Ensure ordering of results of player_elo query - 

### DIFF
--- a/TFCELO.py
+++ b/TFCELO.py
@@ -3268,7 +3268,7 @@ async def on_message(message):
         try:
             if message.guild is None and message.author != client.user:
                 mycursor.execute(
-                    f"SELECT player_elos from player_elo WHERE discord_id = {user.id}"
+                    f"SELECT player_elos from player_elo WHERE discord_id = {user.id} order by entryID"
                 )
                 plotList = []
                 for x in mycursor:


### PR DESCRIPTION
for some reason records for entryID got ordered in a weird way in the table.

This change ensures that the results are always retrieved in ascending order
(Note that this assumes that entryIDs are always increasing, which they should since the column is an autoincrement)