### PR TITLE
Lazy fix for deadlock caused by trying to retrieve the global lock in…

### DIFF
--- a/TFCELO.py
+++ b/TFCELO.py
@@ -3313,7 +3313,10 @@ async def removegame(ctx, number):
         if number in activePickups:
             del activePickups[number]
         elif number in pastTen:
-            await undo(ctx, number)
+            await ctx.send(
+                f"ERROR: Game {number} needs to be undone via !undo first!"
+            )
+            return
         else:
             await ctx.send(
                 f"ERROR: Game {number} not found in active games nor in past ten games!"


### PR DESCRIPTION
… undo when a global lock is being used in removegame. Need to figure out a way to release the lock and then call the next function